### PR TITLE
Bumped dependency on Role::Tiny to 2.000001 to fix fail report.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'Mojolicious', '7.42'; # Mojo::Base::with_roles
 requires 'Mojolicious::Plugin::MountPSGI', '0.07';
 
-requires 'Role::Tiny';
+requires 'Role::Tiny', '2.000001';
 requires 'Class::Method::Modifiers';
 


### PR DESCRIPTION
Hi @jberger 

Please review the PR.
https://www.cpantesters.org/cpan/report/ece80ef2-fc74-11e8-8195-d1a7121562a4

       Role::Tiny 2.000001+ is required for roles at t/basic.t line 6.
       t/basic.t .............. 
       Dubious, test returned 255 (wstat 65280, 0xff00)
       No subtests run 
       t/catalyst/catalyst.t .. skipped: Tests need Catalyst installed to run

Many Thanks.
Best Regards,
Mohammad S Anwar